### PR TITLE
Add SDK methods for public-api

### DIFF
--- a/packages/hubble-sdk/src/Hubble.ts
+++ b/packages/hubble-sdk/src/Hubble.ts
@@ -144,6 +144,23 @@ export class Hubble {
   }
 
   /**
+   * Get all Hubble stability providers (stability pool stats).
+   * @return list of on-chain {@link StabilityProviderState} from the borrowing program
+   */
+  async getStabilityProviders(): Promise<StabilityProviderState[]> {
+    return (
+      await this._borrowingProgram.account.stabilityProviderState.all([
+        {
+          memcmp: {
+            bytes: this._config.borrowing.accounts.stabilityPoolState.toBase58(),
+            offset: 9, // 8 (account discriminator for stability provider state) + 1 (version u8)
+          },
+        },
+      ])
+    ).map((x) => Hubble.stabilityProviderStateToDecimals(x.account as StabilityProviderState));
+  }
+
+  /**
    * Convert user metadata BN fields to Decimal
    * @param user
    * @private
@@ -170,6 +187,23 @@ export class Hubble {
             offset: 50, // 8 (account discriminator for usermetadata) + 1 (version u8) + 1 (status u8) + 8 (user_id u64) + 32 (metadata_pk pubkey [u8, 32])
           },
         },
+        {
+          memcmp: {
+            bytes: this._config.borrowing.accounts.borrowingMarketState.toBase58(),
+            offset: 82, // 8 (account discriminator for usermetadata) + 1 (version u8) + 1 (status u8) + 8 (user_id u64) + 32 (metadata_pk pubkey [u8, 32]) + 32 (owner pubkey)
+          },
+        },
+      ])
+    ).map((x) => Hubble.userMetadataToDecimals(x.account as UserMetadata));
+  }
+
+  /**
+   * Get all Hubble user metadatas (borrowing state, debt, collateral stats...), one user can have multiple borrowing accounts.
+   * @return list of on-chain {@link UserMetadata} from the borrowing program for the specific user with numbers as lamports
+   */
+  async getAllUserMetadatas(): Promise<UserMetadata[]> {
+    return (
+      await this._borrowingProgram.account.userMetadata.all([
         {
           memcmp: {
             bytes: this._config.borrowing.accounts.borrowingMarketState.toBase58(),
@@ -219,6 +253,52 @@ export class Hubble {
   async getUserStakedHbb(user: PublicKey | string): Promise<Decimal> {
     const stakingState = await this.getUserStakingState(user);
     return stakingState.userStake.dividedBy(HBB_DECIMALS);
+  }
+
+  /**
+   * Get Hubble's treasury vault value
+   * @return Value of Hubble's treasury vault in decimal representation
+   */
+  async getTreasuryVault() {
+    const acccountBalance = await this._provider.connection.getTokenAccountBalance(
+      this._config.borrowing.accounts.treasuryVault!
+    );
+    if (!acccountBalance.value.uiAmountString) {
+      throw Error(
+        `Could not get account balance of Hubble treasury vault: ${this._config.borrowing.accounts.treasuryVault}`
+      );
+    }
+    return new Decimal(acccountBalance.value.uiAmountString);
+  }
+
+  /**
+   * Get circulating supply number of the Hubble (HBB) token
+   * @return Number of HBB in circulation in decimal representation
+   */
+  async getHbbCirculatingSupply() {
+    const tokenSupply = await this._provider.connection.getTokenSupply(this._config.borrowing.accounts.mint.HBB);
+    if (!tokenSupply.value.uiAmountString) {
+      throw Error(
+        `Could not get HBB circulating supply from the HBB mint account: ${this._config.borrowing.accounts.mint.HBB}`
+      );
+    }
+    return new Decimal(tokenSupply.value.uiAmountString);
+  }
+
+  /**
+   * Get all token accounts that are holding HBB
+   */
+  getHbbTokenAccounts() {
+    //how to get all token accounts for specific mint: https://spl.solana.com/token#finding-all-token-accounts-for-a-specific-mint
+    //get it from the hardcoded token program and create a filter with the actual mint address
+    //datasize:165 filter selects all token accounts, memcmp filter selects based on the mint address withing each token account
+    const tokenProgram = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+    return this._provider.connection.getParsedProgramAccounts(tokenProgram, {
+      filters: [
+        { dataSize: 165 },
+        { memcmp: { offset: 0, bytes: this._config.borrowing.accounts.mint.HBB.toBase58() } },
+      ],
+    });
   }
 }
 

--- a/packages/hubble-sdk/tests/sdk.test.ts
+++ b/packages/hubble-sdk/tests/sdk.test.ts
@@ -5,11 +5,11 @@ import Decimal from 'decimal.js';
 import Hubble from '../src/Hubble';
 
 describe('Hubble SDK Tests', () => {
-  // let connection: Connection;
+  let connection: Connection;
 
-  // beforeAll(() => {
-  //   connection = new Connection(clusterApiUrl('devnet'));
-  // });
+  beforeAll(() => {
+    connection = new Connection(clusterApiUrl('devnet'));
+  });
 
   test('should throw on invalid cluster', () => {
     const cluster = 'invalid-clusters';
@@ -81,5 +81,40 @@ describe('Hubble SDK Tests', () => {
   //   const sdk = new Hubble('devnet', connection);
   //   const loans = await sdk.getUserLoans('9y7uLMUMW6EiRwH1aJFSp9Zka7dVx2JdZKA3858u6YHT');
   //   console.log('loans : ', loans);
+  // });
+
+  // test('should get all stability providers', async () => {
+  //   const sdk = new Hubble('devnet', connection);
+  //   const stabilityProviderStates = await sdk.getStabilityProviders();
+  //   expect(stabilityProviderStates.length).toBeGreaterThan(0);
+  //   console.log(stabilityProviderStates.length);
+  // });
+
+  // test('should get all user metadatas', async () => {
+  //   const sdk = new Hubble('devnet', connection);
+  //   const userVaults = await sdk.getAllUserMetadatas();
+  //   expect(userVaults.length).toBeGreaterThan(0);
+  //   console.log(userVaults.length);
+  // });
+
+  // test('should get all HBB token accounts', async () => {
+  //   const sdk = new Hubble('devnet', connection);
+  //   const userVaults = await sdk.getHbbTokenAccounts();
+  //   expect(userVaults.length).toBeGreaterThan(0);
+  //   console.log(userVaults.length);
+  // });
+
+  // test('should get treasury vault', async () => {
+  //   const sdk = new Hubble('devnet', connection);
+  //   const treasuryVault = await sdk.getTreasuryVault();
+  //   console.log(treasuryVault);
+  //   expect(treasuryVault.isZero()).toBeFalsy();
+  // });
+
+  // test('should get HBB circulating supply', async () => {
+  //   const sdk = new Hubble('devnet', connection);
+  //   const circulatingSupply = await sdk.getHbbCirculatingSupply();
+  //   console.log(circulatingSupply);
+  //   expect(circulatingSupply.isZero()).toBeFalsy();
   // });
 });

--- a/packages/hubble-sdk/tests/sdk.test.ts
+++ b/packages/hubble-sdk/tests/sdk.test.ts
@@ -5,11 +5,11 @@ import Decimal from 'decimal.js';
 import Hubble from '../src/Hubble';
 
 describe('Hubble SDK Tests', () => {
-  let connection: Connection;
-
-  beforeAll(() => {
-    connection = new Connection(clusterApiUrl('devnet'));
-  });
+  // let connection: Connection;
+  //
+  // beforeAll(() => {
+  //   connection = new Connection(clusterApiUrl('devnet'));
+  // });
 
   test('should throw on invalid cluster', () => {
     const cluster = 'invalid-clusters';


### PR DESCRIPTION
Add the rest of the SDK methods that are used by the public-api, after this is merged our public-api can then fully use the SDK and we can get rid of duplicated code in public-api repository.