### PR TITLE
Leverage Klending

### DIFF
--- a/packages/kamino-sdk/src/Kamino.ts
+++ b/packages/kamino-sdk/src/Kamino.ts
@@ -2121,7 +2121,8 @@ export class Kamino {
     profiler: ProfiledFunctionExecution = noopProfiledFunctionExecution,
     swapIxsBuilder?: SwapperIxBuilder,
     initialUserTokenAtaBalances?: TokensBalances,
-    priceAInB?: Decimal
+    priceAInB?: Decimal,
+    includeAtaIxns: boolean = true // if true it includes create and close wsol and token atas,
   ): Promise<InstructionsWithLookupTables> => {
     const strategyWithAddress = await this.getStrategyStateIfNotFetched(strategy);
 
@@ -2180,7 +2181,8 @@ export class Kamino {
         swapper,
         profiler,
         userTokenBalancesWithoutSolBalanace,
-        priceAInB
+        priceAInB,
+        includeAtaIxns
       ),
       'A-getSingleSidedDepositIxs',
       []
@@ -2195,7 +2197,8 @@ export class Kamino {
     profiler: ProfiledFunctionExecution = noopProfiledFunctionExecution,
     swapIxsBuilder?: SwapperIxBuilder,
     initialUserTokenAtaBalances?: TokensBalances,
-    priceAInB?: Decimal
+    priceAInB?: Decimal,
+    includeAtaIxns: boolean = true // if true it includes create and close wsol and token atas,
   ): Promise<InstructionsWithLookupTables> => {
     const strategyWithAddress = await this.getStrategyStateIfNotFetched(strategy);
 
@@ -2253,7 +2256,8 @@ export class Kamino {
         swapper,
         profiler,
         userTokenBalancesWithoutSolBalanace,
-        priceAInB
+        priceAInB,
+        includeAtaIxns
       ),
       'A-getSingleSidedDepositIxs',
       []
@@ -2307,7 +2311,8 @@ export class Kamino {
     swapIxsBuilder: SwapperIxBuilder,
     profiler: ProfiledFunctionExecution,
     initialUserTokenAtaBalances: TokensBalances,
-    priceAInB?: Decimal // not mandatory as it will be fetched from Jupyter
+    priceAInB?: Decimal, // not mandatory as it will be fetched from Jupyter
+    includeAtaIxns: boolean = true // if true it includes create and close wsol and token atas,
   ): Promise<InstructionsWithLookupTables> => {
     const strategyWithAddress = await this.getStrategyStateIfNotFetched(strategy);
     const strategyState = strategyWithAddress.strategy;
@@ -2493,7 +2498,9 @@ export class Kamino {
     let singleSidedDepositIx = singleTokenDepositWithMin(args, accounts);
 
     let result: TransactionInstruction[] = [];
-    result.push(...createAtasIxns, ...createWsolAtasIxns);
+    if ( includeAtaIxns ) {
+      result.push(...createAtasIxns, ...createWsolAtasIxns);
+    }
 
     // get all unique accounts in the tx so we can use the remaining space (MAX_ACCOUNTS_PER_TRANSACTION - accounts_used) for the swap
     const extractKeys = (ixs: any[]) => ixs.flatMap((ix) => ix.keys?.map((key) => key.pubkey) || []);
@@ -2768,8 +2775,8 @@ export class Kamino {
       expectedBBalance = await this.getTokenAccountBalanceOrZero(tokenBAta);
     }
 
-    let expectedALamports = collToLamportsDecimal(expectedABalance, strategyState.tokenAMintDecimals.toNumber());
-    let expectedBLamports = collToLamportsDecimal(expectedBBalance, strategyState.tokenBMintDecimals.toNumber());
+    let expectedALamports = collToLamportsDecimal(expectedABalance, strategyState.tokenAMintDecimals.toNumber()).floor();
+    let expectedBLamports = collToLamportsDecimal(expectedBBalance, strategyState.tokenBMintDecimals.toNumber()).floor();
 
     const args: CheckExpectedVaultsBalancesArgs = {
       tokenAAtaBalance: new BN(expectedALamports.toString()),

--- a/packages/kamino-sdk/src/Kamino.ts
+++ b/packages/kamino-sdk/src/Kamino.ts
@@ -2522,7 +2522,7 @@ export class Kamino {
     let singleSidedDepositIx = singleTokenDepositWithMin(args, accounts);
 
     let result: TransactionInstruction[] = [];
-    if ( includeAtaIxns ) {
+    if (includeAtaIxns) {
       result.push(...createAtasIxns, ...createWsolAtasIxns);
     }
 
@@ -2799,8 +2799,14 @@ export class Kamino {
       expectedBBalance = await this.getTokenAccountBalanceOrZero(tokenBAta);
     }
 
-    let expectedALamports = collToLamportsDecimal(expectedABalance, strategyState.tokenAMintDecimals.toNumber()).floor();
-    let expectedBLamports = collToLamportsDecimal(expectedBBalance, strategyState.tokenBMintDecimals.toNumber()).floor();
+    let expectedALamports = collToLamportsDecimal(
+      expectedABalance,
+      strategyState.tokenAMintDecimals.toNumber()
+    ).floor();
+    let expectedBLamports = collToLamportsDecimal(
+      expectedBBalance,
+      strategyState.tokenBMintDecimals.toNumber()
+    ).floor();
 
     const args: CheckExpectedVaultsBalancesArgs = {
       tokenAAtaBalance: new BN(expectedALamports.toString()),

--- a/packages/kamino-sdk/src/Kamino.ts
+++ b/packages/kamino-sdk/src/Kamino.ts
@@ -2799,14 +2799,8 @@ export class Kamino {
       expectedBBalance = await this.getTokenAccountBalanceOrZero(tokenBAta);
     }
 
-    let expectedALamports = collToLamportsDecimal(
-      expectedABalance,
-      strategyState.tokenAMintDecimals.toNumber()
-    ).floor();
-    let expectedBLamports = collToLamportsDecimal(
-      expectedBBalance,
-      strategyState.tokenBMintDecimals.toNumber()
-    ).floor();
+    let expectedALamports = collToLamportsDecimal(expectedABalance, strategyState.tokenAMintDecimals.toNumber());
+    let expectedBLamports = collToLamportsDecimal(expectedBBalance, strategyState.tokenBMintDecimals.toNumber());
 
     const args: CheckExpectedVaultsBalancesArgs = {
       tokenAAtaBalance: new BN(expectedALamports.toString()),


### PR DESCRIPTION
This change makes atas optional for `singleSidedDeposit` so that klending can use it, as it creates the atas before calling these functions but within the same transaction.
