### PR TITLE
update skipAta to skip close ixs

### DIFF
--- a/packages/kamino-sdk/src/Kamino.ts
+++ b/packages/kamino-sdk/src/Kamino.ts
@@ -2402,8 +2402,10 @@ export class Kamino {
         }
       }
 
-      createWsolAtasIxns.push(...createWSolAtaIxns.createIxns);
-      cleanupIxs.push(...createWSolAtaIxns.closeIxns);
+      if (includeAtaIxns) {
+        createWsolAtasIxns.push(...createWSolAtaIxns.createIxns);
+        cleanupIxs.push(...createWSolAtaIxns.closeIxns);
+      }
     }
 
     if (isSOLMint(strategyState.tokenBMint)) {
@@ -2441,8 +2443,10 @@ export class Kamino {
         }
       }
 
-      createWsolAtasIxns.push(...createWSolAtaIxns.createIxns);
-      cleanupIxs.push(...createWSolAtaIxns.closeIxns);
+      if (includeAtaIxns) {
+        createWsolAtasIxns.push(...createWSolAtaIxns.createIxns);
+        cleanupIxs.push(...createWSolAtaIxns.closeIxns);
+      }
     }
 
     let amountsToDepositWithSwapPromise = this.calculateAmountsToBeDepositedWithSwap(


### PR DESCRIPTION
Skipping ATA creation should also skip ATA close ixs.

This is required for Klend integration for ktoken leverage and has not impact on the rest of the integrations as it's true by default