### PR TITLE
Kamino sdk small fixes

### DIFF
--- a/packages/kamino-sdk/src/rebalance_methods/driftRebalance.ts
+++ b/packages/kamino-sdk/src/rebalance_methods/driftRebalance.ts
@@ -161,7 +161,7 @@ export function readDriftRebalanceParamsFromStrategy(rebalanceRaw: RebalanceRaw)
   params['startMidTick'] = new Decimal(paramsBuffer.readInt32LE(0));
   params['ticksBelowMid'] = new Decimal(paramsBuffer.readInt32LE(4));
   params['ticksAboveMid'] = new Decimal(paramsBuffer.readInt32LE(8));
-  params['secondsPerTick'] = new Decimal(paramsBuffer.readBigUint64LE(12).toString());
+  params['secondsPerTick'] = new Decimal(paramsBuffer.readBigUInt64LE(12).toString());
   params['direction'] = new Decimal(paramsBuffer.readUint8(20));
 
   return params;
@@ -172,7 +172,7 @@ export function readRawDriftRebalanceStateFromStrategy(rebalanceRaw: RebalanceRa
   let state: RebalanceFieldsDict = {};
 
   state['step'] = new Decimal(stateBuffer.readUInt8(0));
-  state['lastDriftTimestamp'] = new Decimal(stateBuffer.readBigUint64LE(1).toString());
+  state['lastDriftTimestamp'] = new Decimal(stateBuffer.readBigUInt64LE(1).toString());
   state['lastMidTick'] = new Decimal(stateBuffer.readInt32LE(9));
 
   return state;

--- a/packages/kamino-sdk/src/rebalance_methods/periodicRebalance.ts
+++ b/packages/kamino-sdk/src/rebalance_methods/periodicRebalance.ts
@@ -89,7 +89,7 @@ export function readPeriodicRebalanceRebalanceParamsFromStrategy(rebalanceRaw: R
   let paramsBuffer = Buffer.from(rebalanceRaw.params);
   let params: RebalanceFieldsDict = {};
 
-  params['period'] = new Decimal(paramsBuffer.readBigUint64LE(0).toString());
+  params['period'] = new Decimal(paramsBuffer.readBigUInt64LE(0).toString());
   params['lowerRangeBps'] = new Decimal(paramsBuffer.readUInt16LE(8));
   params['upperRangeBps'] = new Decimal(paramsBuffer.readUInt16LE(10));
 
@@ -100,7 +100,7 @@ export function readPeriodicRebalanceRebalanceStateFromStrategy(rebalanceRaw: Re
   let stateBuffer = Buffer.from(rebalanceRaw.state);
   let state: RebalanceFieldsDict = {};
 
-  state['lastRebalanceTimestamp'] = new Decimal(stateBuffer.readBigUint64LE(0).toString());
+  state['lastRebalanceTimestamp'] = new Decimal(stateBuffer.readBigUInt64LE(0).toString());
 
   return state;
 }

--- a/packages/kamino-sdk/src/rebalance_methods/pricePercentageRebalance.ts
+++ b/packages/kamino-sdk/src/rebalance_methods/pricePercentageRebalance.ts
@@ -129,8 +129,8 @@ export function readPricePercentageRebalanceStateFromStrategy(
 ): RebalanceFieldInfo[] {
   let stateBuffer = Buffer.from(rebalanceRaw.state);
 
-  let lowerSqrtPriceX64 = new Decimal(readBigUint128LE(stateBuffer, 0).toString());
-  let upperSqrtPriceX64 = new Decimal(readBigUint128LE(stateBuffer, 16).toString());
+  let lowerSqrtPriceX64 = readBigUint128LE(stateBuffer, 0).toString();
+  let upperSqrtPriceX64 = readBigUint128LE(stateBuffer, 16).toString();
   let lowerPrice: Decimal, upperPrice: Decimal;
 
   if (dex == 'ORCA') {

--- a/packages/kamino-sdk/src/rebalance_methods/pricePercentageWithResetRebalance.ts
+++ b/packages/kamino-sdk/src/rebalance_methods/pricePercentageWithResetRebalance.ts
@@ -212,8 +212,8 @@ export function readPricePercentageWithResetRebalanceStateFromStrategy(
   let resetLowerRangeBps = new Decimal(params.find((param) => param.label == 'resetLowerRangeBps')?.value.toString()!);
   let resetUpperRangeBps = new Decimal(params.find((param) => param.label == 'resetUpperRangeBps')?.value!.toString()!);
 
-  let lowerResetSqrtPriceX64 = new Decimal(readBigUint128LE(stateBuffer, 0).toString());
-  let upperResetSqrtPriceX64 = new Decimal(readBigUint128LE(stateBuffer, 16).toString());
+  let lowerResetSqrtPriceX64 = readBigUint128LE(stateBuffer, 0).toString();
+  let upperResetSqrtPriceX64 = readBigUint128LE(stateBuffer, 16).toString();
 
   let lowerResetPrice: Decimal, upperResetPrice: Decimal;
 

--- a/packages/kamino-sdk/src/utils/utils.ts
+++ b/packages/kamino-sdk/src/utils/utils.ts
@@ -163,7 +163,7 @@ export function lamportsToNumberDecimal(amount: Decimal.Value, decimals: number)
 }
 
 export function readBigUint128LE(buffer: Buffer, offset: number): bigint {
-  return buffer.readBigUint64LE(offset) + (buffer.readBigUint64LE(offset + 8) << BigInt(64));
+  return buffer.readBigUInt64LE(offset) + (buffer.readBigUInt64LE(offset + 8) << BigInt(64));
 }
 
 function writeBNUint64LE(buffer: Buffer, value: BN, offset: number) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Improved data reading accuracy in the Kamino SDK by updating the method used to read unsigned 64-bit integers. This change enhances the reliability of the `driftRebalance`, `periodicRebalance`, and `utils` functions.
- Refactor: Updated the `pricePercentageRebalance` and `pricePercentageWithResetRebalance` functions to assign certain variables as strings directly, removing the usage of the `Decimal` class. The impact on user experience is currently unclear, but this change simplifies the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->