### PR TITLE
Add endpoint for reference price type

### DIFF
--- a/packages/kamino-sdk/src/Kamino.ts
+++ b/packages/kamino-sdk/src/Kamino.ts
@@ -111,6 +111,7 @@ import {
   rebalanceFieldsDictToInfo,
   isVaultInitialized,
   WithdrawAllAndCloseIxns,
+  numberToReferencePriceType,
 } from './utils';
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import {
@@ -441,13 +442,7 @@ export class Kamino {
 
   getReferencePriceTypeForStrategy = async (strategy: PublicKey | StrategyWithAddress): Promise<PriceReferenceType> => {
     const strategyWithAddress = await this.getStrategyStateIfNotFetched(strategy);
-    const referencePriceTypes = this.getPriceReferenceTypes();
-    const strategyReferencePriceType = strategyWithAddress.strategy.rebalanceRaw.referencePriceType;
-
-    if (strategyReferencePriceType >= referencePriceTypes.length) {
-      throw new Error('Strategy has invalid reference price type set');
-    }
-    return referencePriceTypes[strategyReferencePriceType];
+    return numberToReferencePriceType(strategyWithAddress.strategy.rebalanceRaw.referencePriceType);
   };
 
   getFieldsForRebalanceMethod = (

--- a/packages/kamino-sdk/src/Kamino.ts
+++ b/packages/kamino-sdk/src/Kamino.ts
@@ -439,6 +439,17 @@ export class Kamino {
     return getRebalanceMethodFromRebalanceFields(rebalanceFields);
   };
 
+  getReferencePriceTypeForStrategy = async (strategy: PublicKey | StrategyWithAddress): Promise<PriceReferenceType> => {
+    const strategyWithAddress = await this.getStrategyStateIfNotFetched(strategy);
+    const referencePriceTypes = this.getPriceReferenceTypes();
+    const strategyReferencePriceType = strategyWithAddress.strategy.rebalanceRaw.referencePriceType;
+
+    if (strategyReferencePriceType >= referencePriceTypes.length) {
+      throw new Error('Strategy has invalid reference price type set');
+    }
+    return referencePriceTypes[strategyReferencePriceType];
+  };
+
   getFieldsForRebalanceMethod = (
     rebalanceMethod: RebalanceMethod,
     dex: Dex,

--- a/packages/kamino-sdk/src/utils/utils.ts
+++ b/packages/kamino-sdk/src/utils/utils.ts
@@ -120,6 +120,14 @@ export function buildStrategyRebalanceParams(
   return [...buffer];
 }
 
+export function doesStrategyHaveResetRange(rebalanceTypeNumber: number): boolean {
+  let rebalanceType = numberToRebalanceType(rebalanceTypeNumber);
+  return (
+    rebalanceType.kind == RebalanceType.PricePercentageWithReset.kind ||
+    rebalanceType.kind == RebalanceType.Expander.kind
+  );
+}
+
 export function numberToRebalanceType(rebalance_type: number): RebalanceTypeKind {
   if (rebalance_type == 0) {
     return new RebalanceType.Manual();

--- a/packages/kamino-sdk/src/utils/utils.ts
+++ b/packages/kamino-sdk/src/utils/utils.ts
@@ -52,7 +52,7 @@ export function numberToDex(num: number): Dex {
 export function numberToReferencePriceType(num: number): ReferencePriceType {
   let referencePriceType = ReferencePriceType[num];
   if (!referencePriceType) {
-    throw new Error('Strategy has invalid reference price type set');
+    throw new Error(`Strategy has invalid reference price type set: ${num}`);
   }
   return referencePriceType;
 }

--- a/packages/kamino-sdk/src/utils/utils.ts
+++ b/packages/kamino-sdk/src/utils/utils.ts
@@ -13,6 +13,7 @@ import { SqrtPriceMath } from '@raydium-io/raydium-sdk';
 import { token } from '@project-serum/anchor/dist/cjs/utils';
 import { RebalanceFieldInfo, RebalanceFieldsDict } from './types';
 import BN from 'bn.js';
+import { PoolPriceReferenceType, TwapPriceReferenceType } from './priceReferenceTypes';
 
 export const DolarBasedMintingMethod = new Decimal(0);
 export const ProportionalMintingMethod = new Decimal(1);
@@ -25,6 +26,9 @@ export function sleep(ms: number) {
 
 export const Dex = ['ORCA', 'RAYDIUM', 'CREMA'] as const;
 export type Dex = (typeof Dex)[number];
+
+export const ReferencePriceType = [PoolPriceReferenceType, TwapPriceReferenceType] as const;
+export type ReferencePriceType = (typeof ReferencePriceType)[number];
 
 export function dexToNumber(dex: Dex): number {
   for (let i = 0; i < Dex.length; i++) {
@@ -43,6 +47,14 @@ export function numberToDex(num: number): Dex {
     throw new Error(`Unknown DEX ${num}`);
   }
   return dex;
+}
+
+export function numberToReferencePriceType(num: number): ReferencePriceType {
+  let referencePriceType = ReferencePriceType[num];
+  if (!referencePriceType) {
+    throw new Error('Strategy has invalid reference price type set');
+  }
+  return referencePriceType;
 }
 
 export function getDexProgramId(strategyState: WhirlpoolStrategy): PublicKey {


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a method to retrieve the reference price type for a given strategy in the Kamino SDK. This enhances the user's ability to understand and manage their strategies more effectively.
- New Feature: Introduced a utility function that converts a number to a reference price type. This ensures that users are always working with valid price types, improving the reliability of the system.
- New Feature: Added support for new price reference types, PoolPriceReferenceType and TwapPriceReferenceType, providing users with more options for their strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->