### PR TITLE
:wrench: Add kjitosolsol and kmsolsol raydium tokens

### DIFF
--- a/packages/scope-sdk/src/Scope.ts
+++ b/packages/scope-sdk/src/Scope.ts
@@ -143,6 +143,8 @@ export class Scope {
     { id: 115, pair: 'kSOLUSDCOrca/USD', name: 'kSOLUSDCOrca', price: new Decimal(0) },
     { id: 116, pair: 'kJITOSOLUSDCOrca/USD', name: 'kJITOSOLUSDCOrca', price: new Decimal(0) },
     { id: 117, pair: 'LST/SOL', name: 'LST', price: new Decimal(0), nonUsdPairId: 0 },
+    { id: 118, pair: 'kSOLJITOSOLRaydium/USD', name: 'kSOLJITOSOLRaydium', price: new Decimal(0) },
+    { id: 119, pair: 'kSOLMSOLRaydium/USD', name: 'kSOLMSOLRaydium', price: new Decimal(0) },
   ];
 
   /**

--- a/packages/scope-sdk/src/constants/Mints.ts
+++ b/packages/scope-sdk/src/constants/Mints.ts
@@ -85,6 +85,8 @@ export const ScopeMints: { cluster: SolanaCluster; mints: { token: SupportedToke
       { token: 'kSOLUSDCOrca', mint: '8aRT9m1wJ63mnFxeZ3qyBCrwbNMuPKPCEYxpXB41WzYd' },
       { token: 'kJITOSOLUSDCOrca', mint: '8Ak9JgLeTo6ubG5vfpuAR59ANpGjTB8HFDwYjpZbkPeB' },
       { token: 'LST', mint: 'LSTxxxnJzKDFSLr4dUkPcmCf5VyryEqzPLz5j4bpxFp' },
+      { token: 'kSOLJITOSOLRaydium', mint: 'GYiUmJ8reqYAdTQtx6CRFawHqPXx9yzkUFvaUVE8PskP' },
+      { token: 'kSOLMSOLRaydium', mint: '3Fb5DMRWoBLWD36Lp4BtG41LaFjVeEJNCH9YLNPYdVqj' },
     ],
   },
   {

--- a/packages/scope-sdk/src/constants/ScopePairs.ts
+++ b/packages/scope-sdk/src/constants/ScopePairs.ts
@@ -117,5 +117,7 @@ export const ScopePairs = [
   'kSOLUSDCOrca/USD',
   'kJITOSOLUSDCOrca/USD',
   'LST/SOL',
+  'kSOLJITOSOLRaydium/USD',
+  'kSOLMSOLRaydium/USD',
 ] as const;
 export type ScopePair = (typeof ScopePairs)[number];

--- a/packages/scope-sdk/src/constants/SupportedToken.ts
+++ b/packages/scope-sdk/src/constants/SupportedToken.ts
@@ -116,5 +116,7 @@ export const SupportedTokens = [
   'kSOLUSDCOrca',
   'kJITOSOLUSDCOrca',
   'LST',
+  'kSOLJITOSOLRaydium',
+  'kSOLMSOLRaydium',
 ] as const;
 export type SupportedToken = (typeof SupportedTokens)[number];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for two new tokens, 'kSOLJITOSOLRaydium' and 'kSOLMSOLRaydium'. This expands the range of tokens users can interact with.
- New Feature: Introduced 'kSOLJITOSOLRaydium/USD' and 'kSOLMSOLRaydium/USD' pairs, providing users with more trading options.
- Improvement: Updated the 'Scope' class with a new 'oraclePrices' property, enhancing the software's ability to handle price data.

These updates aim to broaden the software's functionality and improve its data handling capabilities, offering users a more diverse and efficient trading experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->