### PR TITLE
Rename tBTC to TBTC

### DIFF
--- a/packages/scope-sdk/src/Scope.ts
+++ b/packages/scope-sdk/src/Scope.ts
@@ -30,7 +30,7 @@ export class Scope {
     { id: 1, pair: 'ETH/USD', name: 'ETH', price: new Decimal(0) },
     { id: 2, pair: 'BTC/USD', name: 'BTC', price: new Decimal(0) },
     { id: 2, pair: 'wBTC/USD', name: 'wBTC', price: new Decimal(0) },
-    { id: 2, pair: 'tBTC/USD', name: 'tBTC', price: new Decimal(0) }, // use the same scope ID as wBTC
+    { id: 2, pair: 'TBTC/USD', name: 'TBTC', price: new Decimal(0) }, // use the same scope ID as wBTC
     { id: 3, pair: 'SRM/USD', name: 'SRM', price: new Decimal(0) },
     { id: 4, pair: 'RAY/USD', name: 'RAY', price: new Decimal(0) },
     { id: 5, pair: 'FTT/USD', name: 'FTT', price: new Decimal(0) },

--- a/packages/scope-sdk/src/constants/Mints.ts
+++ b/packages/scope-sdk/src/constants/Mints.ts
@@ -68,7 +68,7 @@ export const ScopeMints: { cluster: SolanaCluster; mints: { token: SupportedToke
       { token: 'NANA', mint: 'HxRELUQfvvjToVbacjr9YECdfQMUqGgPYB68jVDYxkbr' },
       { token: 'STEP', mint: 'StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT' },
       { token: 'FORGE', mint: 'FoRGERiW7odcCBGU1bztZi16osPBHjxharvDathL5eds' },
-      { token: 'tBTC', mint: '6DNSN2BJsaPFdFFc1zP37kkeNe4Usc1Sqkzr9C9vPWcU' },
+      { token: 'TBTC', mint: '6DNSN2BJsaPFdFFc1zP37kkeNe4Usc1Sqkzr9C9vPWcU' },
       { token: 'COCO', mint: '74DSHnK1qqr4z1pXjLjPAVi8XFngZ635jEVpdkJtnizQ' },
       { token: 'STYLE', mint: '3FHpkMTQ3QyAJoLoXVdBpH4TfHiehnL2kXmv9UXBpYuF' },
       { token: 'CHAI', mint: '3jsFX1tx2Z8ewmamiwSU851GzyzM2DJMq7KWW5DM8Py3' },

--- a/packages/scope-sdk/src/constants/ScopePairs.ts
+++ b/packages/scope-sdk/src/constants/ScopePairs.ts
@@ -94,7 +94,7 @@ export const ScopePairs = [
   'STEPTwap/USD',
   'FORGE/USD',
   'FORGETwap/USD',
-  'tBTC/USD',
+  'TBTC/USD',
   'COCO/USD',
   'COCOTwap/USD',
   'STYLE/USD',

--- a/packages/scope-sdk/src/constants/SupportedToken.ts
+++ b/packages/scope-sdk/src/constants/SupportedToken.ts
@@ -93,7 +93,7 @@ export const SupportedTokens = [
   'STEPTwap',
   'FORGE',
   'FORGETwap',
-  'tBTC',
+  'TBTC',
   'COCO',
   'COCOTwap',
   'STYLE',


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Refactor: Updated token naming conventions across the platform. The token previously referred to as 'tBTC' is now consistently labeled as 'TBTC'. This change enhances the consistency of our platform and makes it easier for users to identify and work with this token. Please note that this is a naming update only and does not affect the functionality or value of the token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->