### PR TITLE
Replace kamino-sdk price methods with map

### DIFF
--- a/packages/kamino-sdk/src/models/EnrichedScopePrice.ts
+++ b/packages/kamino-sdk/src/models/EnrichedScopePrice.ts
@@ -1,5 +1,4 @@
 import Decimal from 'decimal.js';
-import { PublicKey } from '@solana/web3.js';
 import { OraclePrices } from '@hubbleprotocol/scope-sdk';
 import { CollateralInfo } from '../kamino-client/types';
 
@@ -9,19 +8,23 @@ export interface EnrichedScopePrice {
    */
   price: Decimal;
   /**
-   * Token mint
-   */
-  mint: PublicKey;
-  /**
    * Token name (as specified in collateral infos)
    */
   name: string;
 }
 
 export interface KaminoPrices {
-  spot: EnrichedScopePrice[];
-  twap: EnrichedScopePrice[];
+  /**
+   * Spot prices where record key is token mint and value is enriched scope price
+   */
+  spot: MintToPriceMap;
+  /**
+   * Twap prices where record key is token mint and value is enriched scope price
+   */
+  twap: MintToPriceMap;
 }
+
+export type MintToPriceMap = Record<string, EnrichedScopePrice>;
 
 export interface OraclePricesAndCollateralInfos {
   oraclePrices: OraclePrices;

--- a/packages/kamino-sdk/tests/kamino.test.ts
+++ b/packages/kamino-sdk/tests/kamino.test.ts
@@ -325,14 +325,13 @@ describe('Kamino SDK Tests', () => {
     );
     const prices = await kamino.getAllPrices();
     expect(prices).not.to.be.undefined;
-    expect(prices.spot).to.have.length(2);
+    expect(Object.keys(prices.spot)).to.have.length(2);
+    expect(Object.keys(prices.twap)).to.have.length(2);
 
-    expect(prices.twap).to.have.length(2);
-
-    const usdh = prices.spot.find((x) => x.mint.toString() === fixtures.newTokenMintA.toString());
-    const usdc = prices.spot.find((x) => x.mint.toString() === fixtures.newTokenMintB.toString());
-    const usdhTwap = prices.twap.find((x) => x.mint.toString() === fixtures.newTokenMintA.toString());
-    const usdcTwap = prices.twap.find((x) => x.mint.toString() === fixtures.newTokenMintB.toString());
+    const usdh = prices.spot[fixtures.newTokenMintA.toString()];
+    const usdc = prices.spot[fixtures.newTokenMintB.toString()];
+    const usdhTwap = prices.twap[fixtures.newTokenMintA.toString()];
+    const usdcTwap = prices.twap[fixtures.newTokenMintB.toString()];
     expect(usdh).not.to.be.undefined;
     expect(usdh!.name).to.be.equal('USDH');
     expect(usdh!.price.toNumber()).to.be.greaterThan(0);
@@ -1970,9 +1969,9 @@ describe('Kamino SDK Tests', () => {
     const kamino = new Kamino('mainnet-beta', new Connection(clusterApiUrl('mainnet-beta')));
     const prices = await kamino.getAllPrices();
     expect(prices).not.to.be.undefined;
-    expect(prices.spot).to.have.length.greaterThan(0);
-    const usdh = prices.spot.find((x) => x.mint.toString() === 'USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX');
-    const usdhTwap = prices.twap.find((x) => x.mint.toString() === 'USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX');
+    expect(Object.keys(prices.spot)).to.have.length.greaterThan(0);
+    const usdh = prices.spot['USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX'];
+    const usdhTwap = prices.twap['USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX'];
     expect(usdh).not.to.be.undefined;
     expect(usdh!.name).to.be.equal('USDH');
     expect(usdh!.price.toNumber()).to.be.greaterThan(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Refactor:
- Introduced a new type `MintToPriceMap` to streamline price retrieval in the Kamino SDK. This change simplifies the structure of price data, making it easier to access specific prices using a token mint as the key.

Tests:
- Updated tests to reflect the new method of accessing price data. This ensures that our tests accurately represent the updated functionality.

This update enhances the efficiency of price retrieval, improving the overall performance of the Kamino SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->