### PR TITLE
Add @deprecated tag to scope-sdk mint/token methods

### DIFF
--- a/packages/scope-sdk/src/Scope.ts
+++ b/packages/scope-sdk/src/Scope.ts
@@ -25,6 +25,13 @@ export class Scope {
   private readonly _connection: Connection;
   private readonly _config: HubbleConfig;
 
+  /**
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @private
+   */
   private _tokens: ScopeToken[] = [
     { id: 0, pair: 'SOL/USD', name: 'SOL', price: new Decimal(0) },
     { id: 1, pair: 'ETH/USD', name: 'ETH', price: new Decimal(0) },
@@ -158,6 +165,16 @@ export class Scope {
     this._config = getConfigByCluster(cluster);
   }
 
+  /**
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description
+   * @param token
+   * @param prices
+   * @private
+   */
   private async getSinglePrice(token: SupportedToken, prices: OraclePrices) {
     const tokenInfo = this._tokens.find((x) => x.name === token);
     if (!tokenInfo) {
@@ -278,7 +295,11 @@ export class Scope {
   }
 
   /**
-   * Get prices of the specified tokens
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description Get prices of the specified tokens
    * @param tokens list of names of the token
    */
   async getPrices(tokens: SupportedToken[]) {
@@ -291,7 +312,11 @@ export class Scope {
   }
 
   /**
-   * Get prices of the specified token mints
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description Get prices of the specified token mints
    * @param mints list of token mints
    */
   async getPricesByMints(mints: (string | PublicKey)[]) {
@@ -308,21 +333,33 @@ export class Scope {
   }
 
   /**
-   * Get all prices of the supported tokens
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description Get all prices of the supported tokens
    */
   async getAllPrices() {
     return this.getPrices(this._tokens.map((x) => x.name));
   }
 
   /**
-   * Get all mappings of the supported tokens
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description Get all mappings of the supported tokens
    */
   getMappings(): ScopeToken[] {
     return this._tokens;
   }
 
   /**
-   * Get USD price of the specified token
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description Get USD price of the specified token
    * @param token name of the token
    */
   async getPrice(token: SupportedToken) {
@@ -331,7 +368,11 @@ export class Scope {
   }
 
   /**
-   * Get USD price of the specified token mint
+   * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+   * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+   * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+   * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+   * @description Get USD price of the specified token mint
    * @param mint token mint pubkey
    */
   async getPriceByMint(mint: PublicKey | string) {

--- a/packages/scope-sdk/src/ScopeToken.ts
+++ b/packages/scope-sdk/src/ScopeToken.ts
@@ -2,6 +2,13 @@ import { ScopePair, SupportedToken } from './constants';
 import Decimal from 'decimal.js';
 import { PublicKey } from '@solana/web3.js';
 
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description Scope token
+ */
 export interface ScopeToken {
   /**
    * Scope collateral token pair name

--- a/packages/scope-sdk/src/constants/Mints.ts
+++ b/packages/scope-sdk/src/constants/Mints.ts
@@ -1,6 +1,13 @@
 import { SupportedToken } from './SupportedToken';
 import { SolanaCluster } from '@hubbleprotocol/hubble-config';
 
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description Scope mint config
+ */
 export const ScopeMints: { cluster: SolanaCluster; mints: { token: SupportedToken; mint: string }[] }[] = [
   {
     cluster: 'mainnet-beta',
@@ -104,10 +111,28 @@ export const ScopeMints: { cluster: SolanaCluster; mints: { token: SupportedToke
   },
 ];
 
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description Map scope token name to mint
+ * @param token
+ * @param cluster
+ */
 export function scopeTokenToMint(token: SupportedToken, cluster: SolanaCluster = 'mainnet-beta') {
   return ScopeMints.find((x) => x.cluster === cluster)?.mints?.find((x) => x.token === token)?.mint;
 }
 
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description Map token mint to scope token name
+ * @param mint
+ * @param cluster
+ */
 export function mintToScopeToken(mint: string, cluster: SolanaCluster = 'mainnet-beta') {
   return ScopeMints.find((x) => x.cluster === cluster)?.mints?.find((x) => x.mint === mint)?.token;
 }

--- a/packages/scope-sdk/src/constants/ScopePairs.ts
+++ b/packages/scope-sdk/src/constants/ScopePairs.ts
@@ -1,3 +1,10 @@
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description Scope pair config
+ */
 export const ScopePairs = [
   'SOL/USD',
   'ETH/USD',
@@ -120,4 +127,11 @@ export const ScopePairs = [
   'kSOLJITOSOLRaydium/USD',
   'kSOLMSOLRaydium/USD',
 ] as const;
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description
+ */
 export type ScopePair = (typeof ScopePairs)[number];

--- a/packages/scope-sdk/src/constants/SupportedToken.ts
+++ b/packages/scope-sdk/src/constants/SupportedToken.ts
@@ -1,3 +1,10 @@
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description Supported scope tokens
+ */
 export const SupportedTokens = [
   'SOL',
   'ETH',
@@ -119,4 +126,11 @@ export const SupportedTokens = [
   'kSOLJITOSOLRaydium',
   'kSOLMSOLRaydium',
 ] as const;
+/**
+ * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.
+ * @see [hubble-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0512e85c5a816a557fe7feaf55981cabcd992476/packages/hubble-sdk/src/Hubble.ts#L722} getAllPrices method
+ * @see [kamino-sdk]{@link https://github.com/hubbleprotocol/hubble-common/blob/0be269d4fdb3dbadbbd8c7fcca68c6b1928d445a/packages/kamino-sdk/src/Kamino.ts#L1717} getAllPrices method
+ * @see [kamino-lending-sdk]{@link https://github.com/hubbleprotocol/kamino-lending-sdk/blob/17a48b6bb21945d2d799d31d6f0b20104e8c83ac/src/classes/market.ts#L759} getAllScopePrices method
+ * @description
+ */
 export type SupportedToken = (typeof SupportedTokens)[number];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Deprecations:
- Deprecated several functions in the Scope SDK, including `getPrices`, `getPricesByMints`, `getAllPrices`, `getMappings`, `getPrice`, and `getPriceByMint`. These changes are part of our ongoing efforts to streamline our SDK and direct users towards more efficient and updated methods. Please refer to the provided links for alternative methods or SDK clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->