### PR TITLE
add new RENDER token

### DIFF
--- a/packages/scope-sdk/src/Scope.ts
+++ b/packages/scope-sdk/src/Scope.ts
@@ -152,10 +152,8 @@ export class Scope {
     { id: 117, pair: 'LST/SOL', name: 'LST', price: new Decimal(0), nonUsdPairId: 0 },
     { id: 118, pair: 'kSOLJITOSOLRaydium/USD', name: 'kSOLJITOSOLRaydium', price: new Decimal(0) },
     { id: 119, pair: 'kSOLMSOLRaydium/USD', name: 'kSOLMSOLRaydium', price: new Decimal(0) },
-    { id: 120, pair: 'RNDR/USD', name: 'RNDR', price: new Decimal(0) },
-    { id: 121, pair: 'RNDREma/USD', name: 'RNDREma', price: new Decimal(0) },
-    { id: 122, pair: 'RENDER/USD', name: 'RNDR', price: new Decimal(0) },
-    { id: 123, pair: 'RENDEREma/USD', name: 'RNDREma', price: new Decimal(0) },
+    { id: 122, pair: 'RENDER/USD', name: 'RENDER', price: new Decimal(0) },
+    { id: 123, pair: 'RENDEREma/USD', name: 'RENDEREma', price: new Decimal(0) },
   ];
 
   /**

--- a/packages/scope-sdk/src/Scope.ts
+++ b/packages/scope-sdk/src/Scope.ts
@@ -154,6 +154,8 @@ export class Scope {
     { id: 119, pair: 'kSOLMSOLRaydium/USD', name: 'kSOLMSOLRaydium', price: new Decimal(0) },
     { id: 120, pair: 'RNDR/USD', name: 'RNDR', price: new Decimal(0) },
     { id: 121, pair: 'RNDREma/USD', name: 'RNDREma', price: new Decimal(0) },
+    { id: 122, pair: 'RENDER/USD', name: 'RNDR', price: new Decimal(0) },
+    { id: 123, pair: 'RENDEREma/USD', name: 'RNDREma', price: new Decimal(0) },
   ];
 
   /**

--- a/packages/scope-sdk/src/constants/Mints.ts
+++ b/packages/scope-sdk/src/constants/Mints.ts
@@ -94,7 +94,6 @@ export const ScopeMints: { cluster: SolanaCluster; mints: { token: SupportedToke
       { token: 'LST', mint: 'LSTxxxnJzKDFSLr4dUkPcmCf5VyryEqzPLz5j4bpxFp' },
       { token: 'kSOLJITOSOLRaydium', mint: 'GYiUmJ8reqYAdTQtx6CRFawHqPXx9yzkUFvaUVE8PskP' },
       { token: 'kSOLMSOLRaydium', mint: '3Fb5DMRWoBLWD36Lp4BtG41LaFjVeEJNCH9YLNPYdVqj' },
-      { token: 'RNDR', mint: 'J39SiMc21133mMNZ5K46Z4ZwFa2oQrKHBh8iujqckdxN' },
       { token: 'RENDER', mint: 'rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof' },
     ],
   },

--- a/packages/scope-sdk/src/constants/Mints.ts
+++ b/packages/scope-sdk/src/constants/Mints.ts
@@ -95,6 +95,7 @@ export const ScopeMints: { cluster: SolanaCluster; mints: { token: SupportedToke
       { token: 'kSOLJITOSOLRaydium', mint: 'GYiUmJ8reqYAdTQtx6CRFawHqPXx9yzkUFvaUVE8PskP' },
       { token: 'kSOLMSOLRaydium', mint: '3Fb5DMRWoBLWD36Lp4BtG41LaFjVeEJNCH9YLNPYdVqj' },
       { token: 'RNDR', mint: 'J39SiMc21133mMNZ5K46Z4ZwFa2oQrKHBh8iujqckdxN' },
+      { token: 'RENDER', mint: 'rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof' },
     ],
   },
   {

--- a/packages/scope-sdk/src/constants/ScopePairs.ts
+++ b/packages/scope-sdk/src/constants/ScopePairs.ts
@@ -128,6 +128,8 @@ export const ScopePairs = [
   'kSOLMSOLRaydium/USD',
   'RNDR/USD',
   'RNDREma/USD',
+  'RENDER/USD',
+  'RENDEREma/USD',
 ] as const;
 /**
  * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.

--- a/packages/scope-sdk/src/constants/ScopePairs.ts
+++ b/packages/scope-sdk/src/constants/ScopePairs.ts
@@ -126,8 +126,6 @@ export const ScopePairs = [
   'LST/SOL',
   'kSOLJITOSOLRaydium/USD',
   'kSOLMSOLRaydium/USD',
-  'RNDR/USD',
-  'RNDREma/USD',
   'RENDER/USD',
   'RENDEREma/USD',
 ] as const;

--- a/packages/scope-sdk/src/constants/SupportedToken.ts
+++ b/packages/scope-sdk/src/constants/SupportedToken.ts
@@ -127,6 +127,8 @@ export const SupportedTokens = [
   'kSOLMSOLRaydium',
   'RNDR',
   'RNDREma',
+  'RENDER',
+  'RENDEREma',
 ] as const;
 /**
  * @deprecated Deprecated since version 2.2.47 - please use {@link getOraclePrices} or the respective SDK client instead.

--- a/packages/scope-sdk/src/constants/SupportedToken.ts
+++ b/packages/scope-sdk/src/constants/SupportedToken.ts
@@ -125,8 +125,6 @@ export const SupportedTokens = [
   'LST',
   'kSOLJITOSOLRaydium',
   'kSOLMSOLRaydium',
-  'RNDR',
-  'RNDREma',
   'RENDER',
   'RENDEREma',
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added 'RENDER/USD' and 'RENDEREma/USD' to the list of supported trading pairs.
	- Introduced 'RENDER' and 'RENDEREma' as new supported tokens.
- **Bug Fixes**
	- Corrected the token symbol from 'RNDR' to 'RENDER' and updated the associated mint address.
- **Deprecations**
	- Deprecated 'RNDR/USD' and 'RNDREma/USD' trading pairs.
	- Deprecated 'RNDR' and 'RNDREma' tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->